### PR TITLE
fix(encoding): export environment variables for UTF-8 support

### DIFF
--- a/Dockerfile.yum
+++ b/Dockerfile.yum
@@ -13,7 +13,12 @@ RUN pip install anchorecli
 RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm && \
   yum install -y google-chrome-stable_current_x86_64.rpm && \
   yum install -y Xvfb
- 
+
+# Set the locale(en_US.UTF-8)
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+
 # Git
 RUN curl -o ./endpoint-repo-1.7-1.x86_64.rpm https://packages.endpoint.com/rhel/7/os/x86_64/endpoint-repo-1.7-1.x86_64.rpm && \
   rpm -Uvh endpoint-repo*rpm && \


### PR DESCRIPTION
# Issue detected
While using the [builder-maven](https://github.com/jenkins-x/builder-maven), some tests were failing due to the usage of UTF-8 characters

# How is this PR trying to solve the issue?
It exports the appropriate variables at container build time to set UTF-8 by default in an image based `FROM centos:7`.
