### PR TITLE
Upgrade SKAFFOLD_VERSION to 0.11.0

### DIFF
--- a/Dockerfile.common
+++ b/Dockerfile.common
@@ -47,7 +47,7 @@ RUN curl -L https://github.com/fabric8io/exposecontroller/releases/download/v$EX
   mv exposecontroller /usr/bin/
 
 # skaffold
-ENV SKAFFOLD_VERSION 0.10.0
+ENV SKAFFOLD_VERSION 0.11.0
 RUN curl -Lo skaffold https://github.com/GoogleCloudPlatform/skaffold/releases/download/v${SKAFFOLD_VERSION}/skaffold-linux-amd64 && \
   chmod +x skaffold && \
   mv skaffold /usr/bin


### PR DESCRIPTION
The Skaffold release 0.11.0 fixes a number of issues related to Docker multi-stage builds and multi-artifact builds: https://github.com/GoogleContainerTools/skaffold/releases/tag/v0.11.0